### PR TITLE
Include stdio.h to remove compiler warning 

### DIFF
--- a/src/XMotif/XmDrawdbl.c
+++ b/src/XMotif/XmDrawdbl.c
@@ -27,6 +27,7 @@
 */
 
 #include <Xm/DrawingA.h>
+#include <stdio.h>
 #include <stdlib.h>
 #include "pigdefs.h"
 

--- a/src/XMotif/XmMain.c
+++ b/src/XMotif/XmMain.c
@@ -25,6 +25,8 @@
   !***********************************************************************
 */
 
+#include <stdio.h>
+
 #include "XmMain.h"
 #include "pigdefs.h"
 
@@ -693,7 +695,7 @@ void fileok_cb (Widget widget, XtPointer client_data, XtPointer call_data)
     
     if (!*filename) {
         /* nothing typed? */
-        puts ("No file selected.");
+        printf("No file selected.");
 
         XtFree (filename);
         


### PR DESCRIPTION
Include stdio.h to remove compiler warning about printf being an undefined function (#12). Changed puts to printf since puts also wasn't defined.